### PR TITLE
Use nfdiv-common-lib removeAllPetitionDocuments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ def versions = [
         commonsIo                    : '2.6',
         commonsLang3                 : '3.9',
         commonsMath3                 : '3.6.1',
-        divCommonLib                 : '1.3.1',
+        divCommonLib                 : '1.4.0',
         dumbster                     : '1.7.1',
         elasticsearch                : '7.9.3',
         feignHttpClient              : '10.3.0',

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
@@ -16,13 +16,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @FeignClient(name = "formatter-service-client", url = "${case.formatter.service.api.baseurl}")
 public interface CaseFormatterClient {
 
-    @ApiOperation("Remove all Petition documents from case data")
-    @PostMapping(value = "/caseformatter/version/1/remove-all-petition-documents",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
-    Map<String, Object> removeAllPetitionDocuments(
-        @RequestBody Map<String, Object> caseData
-    );
-
     @ApiOperation("Remove all documents by document type")
     @PostMapping(value = "/caseformatter/version/1/remove/documents/{documentType}",
         headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RemoveMiniPetitionDraftDocumentsTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RemoveMiniPetitionDraftDocumentsTask.java
@@ -2,24 +2,24 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.service.CaseFormatterService;
 
 import java.util.Map;
 
 @Component
 public class RemoveMiniPetitionDraftDocumentsTask implements Task<Map<String, Object>> {
 
-    private final CaseFormatterClient caseFormatterClient;
+    private final CaseFormatterService caseFormatterService;
 
     @Autowired
-    public RemoveMiniPetitionDraftDocumentsTask(final CaseFormatterClient caseFormatterClient) {
-        this.caseFormatterClient = caseFormatterClient;
+    public RemoveMiniPetitionDraftDocumentsTask(final CaseFormatterService caseFormatterService) {
+        this.caseFormatterService = caseFormatterService;
     }
 
     @Override
     public Map<String, Object> execute(final TaskContext context, final Map<String, Object> caseData) {
-        return caseFormatterClient.removeAllPetitionDocuments(caseData);
+        return caseFormatterService.removeAllPetitionDocuments(caseData);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentAbstractITest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/functionaltest/ProcessPbaPaymentAbstractITest.java
@@ -110,7 +110,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
 
     private static final String API_URL = "/process-pba-payment";
     private static final String PAYMENTS_CREDIT_ACCOUNT_CONTEXT_PATH = "/credit-account-payments";
-    private static final String FORMAT_REMOVE_PETITION_DOCUMENTS_CONTEXT_PATH = "/caseformatter/version/1/remove-all-petition-documents";
     private static final String EAST_MIDLANDS_RDC = "East Midlands Regional Divorce Centre";
 
     @MockBean
@@ -280,8 +279,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
             .data(caseData)
             .build();
 
-        stubFormatterServerEndpoint(caseData);
-
         webClient.perform(post(API_URL)
             .content(convertObjectToJsonString(ccdCallbackRequest))
             .header(AUTHORIZATION, AUTH_TOKEN)
@@ -308,7 +305,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
 
         Map<String, Object> workFlowCaseDataResponse = new HashMap<>(caseData);
         workFlowCaseDataResponse.put(ProcessPbaPaymentTask.PAYMENT_STATUS, PaymentStatus.PENDING.value());
-        stubFormatterServerEndpoint(workFlowCaseDataResponse);
 
         stubCreditAccountPayment(HttpStatus.OK, CreditAccountPaymentResponse.builder()
             .status(PaymentStatus.PENDING.value())
@@ -353,7 +349,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
             .build());
 
         stubServiceAuthProvider(HttpStatus.OK, TEST_SERVICE_AUTH_TOKEN);
-        stubFormatterServerEndpoint(workFlowCaseDataResponse);
 
         CcdCallbackResponse expected = CcdCallbackResponse.builder()
             .state(CcdStates.SUBMITTED)
@@ -494,7 +489,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
 
         Map<String, Object> workFlowCaseDataResponse = new HashMap<>(caseData);
         workFlowCaseDataResponse.put(ProcessPbaPaymentTask.PAYMENT_STATUS, PaymentStatus.SUCCESS.value());
-        stubFormatterServerEndpoint(workFlowCaseDataResponse);
 
         stubCreditAccountPayment(HttpStatus.OK, CreditAccountPaymentResponse.builder()
             .status(PaymentStatus.SUCCESS.value())
@@ -547,7 +541,6 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
                             CreditAccountPaymentResponse errorCreditAccountPaymentResponse) {
         stubCreditAccountPayment(httpStatus, errorCreditAccountPaymentResponse);
         stubServiceAuthProvider(HttpStatus.OK, TEST_SERVICE_AUTH_TOKEN);
-        stubFormatterServerEndpoint(caseData);
     }
 
     private void stubCreditAccountPayment(HttpStatus status, CreditAccountPaymentResponse response) {
@@ -559,14 +552,5 @@ public abstract class ProcessPbaPaymentAbstractITest extends MockedFunctionalTes
                 .withStatus(status.value())
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                 .withBody(convertObjectToJsonString(response))));
-    }
-
-    private void stubFormatterServerEndpoint(Map<String, Object> data) {
-        formatterServiceServer.stubFor(WireMock.post(FORMAT_REMOVE_PETITION_DOCUMENTS_CONTEXT_PATH)
-            .withRequestBody(equalToJson(convertObjectToJsonString(data)))
-            .willReturn(aResponse()
-                .withStatus(HttpStatus.OK.value())
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-                .withBody(convertObjectToJsonString(data))));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RemoveMiniPetitionDraftDocumentsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/RemoveMiniPetitionDraftDocumentsTaskTest.java
@@ -5,8 +5,8 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.DefaultTaskContext;
+import uk.gov.hmcts.reform.divorce.service.CaseFormatterService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 public class RemoveMiniPetitionDraftDocumentsTaskTest {
 
     @Mock
-    private CaseFormatterClient caseFormatterClient;
+    private CaseFormatterService caseFormatterService;
 
     @InjectMocks
     private RemoveMiniPetitionDraftDocumentsTask removeMiniPetitionDraftDocumentsTask;
@@ -28,11 +28,11 @@ public class RemoveMiniPetitionDraftDocumentsTaskTest {
         final Map<String, Object> payload = new HashMap<>();
 
         //given
-        when(caseFormatterClient.removeAllPetitionDocuments(payload)).thenReturn(payload);
+        when(caseFormatterService.removeAllPetitionDocuments(payload)).thenReturn(payload);
 
         //when
         removeMiniPetitionDraftDocumentsTask.execute(new DefaultTaskContext(), payload);
 
-        verify(caseFormatterClient).removeAllPetitionDocuments(payload);
+        verify(caseFormatterService).removeAllPetitionDocuments(payload);
     }
 }


### PR DESCRIPTION
# Description
Remove CFS service calls to remove all petition documents.
Add use of nfdiv-common-lib removeAllPetitionDocuments method.

https://tools.hmcts.net/jira/browse/NFDIV-338

