### PR TITLE
Use nfdiv-common-lib getDnClarificationCaseData and getDnCaseData

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/client/CaseFormatterClient.java
@@ -29,18 +29,4 @@ public interface CaseFormatterClient {
     Map<String, Object> transformToAosCaseFormat(
         @RequestBody Map<String, Object> divorceSession
     );
-
-    @ApiOperation("Transform data to DN Submit Format")
-    @PostMapping(value = "/caseformatter/version/1/to-dn-submit-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
-    Map<String, Object> transformToDnCaseFormat(
-        @RequestBody Map<String, Object> divorceSession
-    );
-
-    @ApiOperation("Transform data to DN Clarification Format")
-    @PostMapping(value = "/caseformatter/version/1/to-dn-clarification-format",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE)
-    Map<String, Object> transformToDnClarificationCaseFormat(
-        @RequestBody Map<String, Object> divorceCaseWrapper
-    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseDataTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/tasks/FormatDivorceSessionToDnCaseDataTask.java
@@ -3,10 +3,10 @@ package uk.gov.hmcts.reform.divorce.orchestration.tasks;
 import com.google.common.collect.ImmutableMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.divorce.orchestration.client.CaseFormatterClient;
 import uk.gov.hmcts.reform.divorce.orchestration.domain.model.ccd.CaseDetails;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.Task;
 import uk.gov.hmcts.reform.divorce.orchestration.framework.workflow.task.TaskContext;
+import uk.gov.hmcts.reform.divorce.service.CaseFormatterService;
 
 import java.util.Map;
 
@@ -19,7 +19,7 @@ import static uk.gov.hmcts.reform.divorce.orchestration.domain.model.Orchestrati
 @RequiredArgsConstructor
 public class FormatDivorceSessionToDnCaseDataTask implements Task<Map<String, Object>> {
 
-    private final CaseFormatterClient caseFormatterClient;
+    private final CaseFormatterService caseFormatterService;
 
     @Override
     public Map<String, Object> execute(TaskContext context, Map<String, Object> sessionData) {
@@ -30,9 +30,9 @@ public class FormatDivorceSessionToDnCaseDataTask implements Task<Map<String, Ob
                 FORMATTER_CASE_DATA_KEY, caseDetails.getCaseData(),
                 FORMATTER_DIVORCE_SESSION_KEY, sessionData
             );
-            return caseFormatterClient.transformToDnClarificationCaseFormat(divorceCaseWrapper);
+            return caseFormatterService.getDnClarificationCaseData(divorceCaseWrapper);
         }
 
-        return caseFormatterClient.transformToDnCaseFormat(sessionData);
+        return caseFormatterService.getDnCaseData(sessionData);
     }
 }


### PR DESCRIPTION
# Description
Remove CFS call to-dn-clarification-format and  to-dn-submit-format endpoints
Use nfdiv-common-lib CaseFormatterService.getDnClarificationCaseData method
Use nfdiv-common-lib CaseFormatterService.getDnCaseData method

https://tools.hmcts.net/jira/browse/NFDIV-343
https://tools.hmcts.net/jira/browse/NFDIV-344
