### PR TITLE
Add sourceCompatibility to job-scheduler gradle.build file.

### DIFF
--- a/job-scheduler/build.gradle
+++ b/job-scheduler/build.gradle
@@ -1,3 +1,4 @@
+sourceCompatibility = 11
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
this seems to fix the
```
Could not determine the dependencies of task ':bootJar'.
> Could not resolve all task dependencies for configuration ':runtimeClasspath'.
   > Could not resolve project :job-scheduler.
     Required by:
         project :
      > No matching variant of project :job-scheduler was found. The consumer was configured to find a runtime of a library compatible with Java 11, packaged as a jar, and its dependencies declared externally but:
          - Variant 'apiElements' capability uk.gov.hmcts.reform.divorce:job-scheduler:0.0.1 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 14 and the consumer needed a runtime of a component compatible with Java 11
          - Variant 'runtimeElements' capability uk.gov.hmcts.reform.divorce:job-scheduler:0.0.1 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 14 and the consumer needed a component compatible with Java 11
```
issue when building `nfdiv-case-orchestration-service`.