### PR TITLE
Fixed exception handler method argument and test

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/orchestration/controller/GetCaseITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/orchestration/controller/GetCaseITest.java
@@ -122,7 +122,7 @@ public class GetCaseITest extends IdamTestSupport {
             .thenReturn(null);
 
         webClient.perform(get(GET_CASE_CONTEXT_PATH)
-            .header(AUTHORIZATION, AUTH_TOKEN)
+            .header(AUTHORIZATION, USER_TOKEN)
             .accept(APPLICATION_JSON))
             .andExpect(status().isNotFound());
     }

--- a/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/orchestration/controller/advice/GlobalExceptionHandler.java
@@ -69,7 +69,7 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(CaseNotFoundException.class)
-    ResponseEntity<Object> handleCaseNotFoundException(InvalidDataException exception) {
+    ResponseEntity<Object> handleCaseNotFoundException(CaseNotFoundException exception) {
         log.warn(exception.getMessage(), exception);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).build();


### PR DESCRIPTION
- Test Idam token was used instead of Bearer user token which resulted in FeignException 404 when retrieving user details as the stub request header didn't match and test assertion checked for 404 and hence it passed.
- Test should have not failed for Idam and instead failed while retrieving case from CCD which is fixed now.
- Exception handler method argument was incorrect which is also fixed by this PR.